### PR TITLE
Fix: Backlog report filters and delivery validation

### DIFF
--- a/llantascs_customs/llantascs_customs/api.py
+++ b/llantascs_customs/llantascs_customs/api.py
@@ -270,8 +270,8 @@ def _cost_from_gl_entries(si_name: str) -> float:
         FROM `tabGL Entry`
         WHERE voucher_type = 'Sales Invoice'
           AND voucher_no   = %s
-          AND account      IN %(accs)s
-    """, (si_name, {"accs": tuple(cogs_accounts)}), as_dict=True)
+          AND account      IN %s
+    """, (si_name, tuple(cogs_accounts)), as_dict=True)
 
     return abs(flt(row[0].cogs)) if row and row[0].cogs is not None else 0.0
 
@@ -462,20 +462,28 @@ def get_sales_invoices(sucursal, fecha_inicial, fecha_final):
         """
         Consideramos 'entregada' si:
           - La factura hizo update_stock (ya descargó inventario), o
-          - Tiene Delivery Notes vinculados con qty entregada > 0
+          - TODOS los items de stock tienen entrega completa:
+            (delivered_qty + delivered_by_supplier) >= qty
         """
-        upd = frappe.db.get_value("Sales Invoice", si_name, "update_stock")
-        if upd:
+        si = frappe.get_doc("Sales Invoice", si_name)
+
+        # Si update_stock=1, ya descargó inventario automáticamente
+        if si.update_stock:
             return True
 
-        # ¿Tiene al menos un Delivery Note vinculado?
-        has_dn = frappe.db.sql("""
-            SELECT 1
-            FROM `tabSales Invoice Item`
-            WHERE parent = %s AND IFNULL(delivery_note, '') != ''
-            LIMIT 1
-        """, (si_name,))
-        return bool(has_dn)
+        # Validar entrega completa para items de stock
+        for item in si.items:
+            # Verificar si es item de stock (usar cached para performance)
+            item_doc = frappe.get_cached_doc("Item", item.item_code)
+            if not item_doc.is_stock_item:
+                continue  # Servicios no requieren entrega
+
+            # Validar entrega completa
+            total_delivered = flt(item.delivered_qty) + flt(item.delivered_by_supplier)
+            if total_delivered < item.qty:
+                return False  # Entrega incompleta
+
+        return True  # Todos los items de stock están completamente entregados
 
     # Post-filtrado por entrega según tipo de items
     out = []

--- a/llantascs_customs/llantascs_customs/report/backlog_comisiones_gp_nativo/backlog_comisiones_gp_nativo.py
+++ b/llantascs_customs/llantascs_customs/report/backlog_comisiones_gp_nativo/backlog_comisiones_gp_nativo.py
@@ -157,6 +157,7 @@ base_si as (
   from `tabSales Invoice` si
   where si.docstatus = 1
     and si.posting_date between %(from_date)s and %(to_date)s
+    and (si.custom_status_comisiones IS NULL OR si.custom_status_comisiones = 'Sin Enviar')
     and not exists (
       select 1
       from `tabClientes Sin Comision` ex

--- a/llantascs_customs/llantascs_customs/report/backlog_comisiones_gp_nativo/backlog_comisiones_gp_nativo.py
+++ b/llantascs_customs/llantascs_customs/report/backlog_comisiones_gp_nativo/backlog_comisiones_gp_nativo.py
@@ -200,10 +200,12 @@ CASE
     WHERE sii.parent = si.name AND i.is_stock_item = 1
   ) THEN 1
   WHEN si.update_stock = 1 THEN 1
-  WHEN EXISTS (
-    SELECT 1 FROM `tabDelivery Note Item` dni
-    INNER JOIN `tabDelivery Note` dn ON dn.name = dni.parent AND dn.docstatus = 1
-    WHERE dni.against_sales_invoice = si.name
+  WHEN NOT EXISTS (
+    SELECT 1 FROM `tabSales Invoice Item` sii
+    INNER JOIN `tabItem` i ON i.name = sii.item_code
+    WHERE sii.parent = si.name
+      AND i.is_stock_item = 1
+      AND (IFNULL(sii.delivered_qty, 0) + IFNULL(sii.delivered_by_supplier, 0)) < sii.qty
   ) THEN 1
   ELSE 0
 END AS "Entrega OK:Check:80",


### PR DESCRIPTION
## 🎯 Problemas Resueltos

### 1. Backlog muestra facturas con status "Enviado" como pendientes
**Síntoma**: Reporte "Backlog Comisiones GP Nativo" mostraba facturas ya procesadas
- 360 facturas con status "Enviado" o "Pagada" aparecían en backlog
- Confusión: facturas en backlog pero no se podían incluir en nuevas OPC
- Datos históricos inconsistentes: facturas marcadas "Enviado" sin comisiones en BD

**Causa**: Query no filtraba por `custom_status_comisiones`

**Solución**: 
```sql
-- Línea 160 en backlog_comisiones_gp_nativo.py
AND (si.custom_status_comisiones IS NULL OR si.custom_status_comisiones = 'Sin Enviar')
```

### 2. OPC excluye facturas con entrega completa vía delivered_qty
**Síntoma**: Diferencia entre Backlog y OPC
- Backlog: 19 facturas
- OPC: 3 facturas
- Diferencia: 16 facturas

**Causa raíz**: `_delivered()` solo verificaba existencia de Delivery Note
- 5 facturas tenían `delivered_qty == qty` (entrega completa)
- Pero NO tenían Delivery Note vinculado
- `_delivered()` las marcaba como NO entregadas incorrectamente

**Solución**:
```python
# api.py:461-486
def _delivered(si_name: str) -> bool:
    # Validar entrega COMPLETA para items de stock
    for item in si.items:
        total_delivered = flt(item.delivered_qty) + flt(item.delivered_by_supplier)
        if total_delivered < item.qty:
            return False  # Entrega incompleta
    return True
```

### 3. TypeError en _cost_from_gl_entries()
**Síntoma**: Error al hacer clic en "Actualizar Listado" en OPC
```
TypeError: dict can not be used as parameter
```

**Causa**: Parámetro SQL incorrecto en línea 274
```python
# ❌ INCORRECTO
(si_name, {"accs": tuple(cogs_accounts)})

# ✅ CORRECTO
(si_name, tuple(cogs_accounts))
```

## 📝 Cambios Implementados

### 1. `backlog_comisiones_gp_nativo.py`
- **Línea 160**: Agregar filtro `custom_status_comisiones`
- **Líneas 196-211**: Actualizar query "Entrega OK" para validar `delivered_qty`

### 2. `api.py`
- **Líneas 461-486**: Refactorizar `_delivered()` para validar entrega completa
- **Líneas 268-274**: Fix parámetros SQL en `_cost_from_gl_entries()`

## ✅ Verificación

### Facturas con entrega completa (delivered_qty == qty)
- ✓ ACC-SINV-2025-00444 (10.0/10.0) - Incluida correctamente
- ✓ ACC-SINV-2025-00854 (1.0/1.0) - Incluida correctamente
- ✓ ACC-SINV-2025-02976 (10.0/10.0) - Incluida correctamente
- ✓ ACC-SINV-2025-03190 (1.0/1.0) - Incluida correctamente
- ✓ ACC-SINV-2025-03246 (7.0/7.0) - Incluida correctamente

### Facturas con entrega incompleta
- ✓ ACC-SINV-2025-03723 (1.0/2.0) - Excluida correctamente

### Facturas con status "Enviado"
- ✓ ACC-SINV-2025-00679 - Excluida de backlog correctamente

### Consistencia
- ✓ API vs SQL query: MATCH perfecto (8 facturas)
- ✓ OPC "Actualizar Listado" funciona sin errores
- ✓ Backlog y OPC ahora consistentes

## 📊 Impacto

- **360 facturas** con status "Enviado/Pagada" correctamente excluidas de backlog
- **5 facturas** con entrega completa ahora incluidas en OPC
- **1 factura** con entrega incompleta correctamente excluida
- **Consistencia** total entre Backlog y OPC
- **Prevención** de duplicación de comisiones por datos históricos inconsistentes

## 🧪 Test Plan

- [x] Verificar que facturas con `custom_status_comisiones = "Enviado"` NO aparecen en backlog
- [x] Verificar que facturas con `delivered_qty + delivered_by_supplier >= qty` se incluyen en OPC
- [x] Verificar que facturas con entrega incompleta NO se incluyen en OPC
- [x] Verificar que "Actualizar Listado" en OPC funciona sin errores
- [x] Verificar consistencia entre Backlog y OPC para mismo período/sucursal

## 🔗 Referencias

- **Issue investigado**: COMISIONES-2025-10-06-07066 (0 comisiones de servicios)
- **Issue investigado**: COMISIONES-2025-10-06-07067 (diferencia OPC vs Backlog)
- **Facturas de prueba**: ACC-SINV-2025-00679, ACC-SINV-2025-00444, ACC-SINV-2025-03723

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)