### PR TITLE
fix: aumentar tolerancia redondeo validación OPC (/bin/bash.01 → /bin/bash.05)

### DIFF
--- a/llantascs_customs/one_offs/validar_opc_final.py
+++ b/llantascs_customs/one_offs/validar_opc_final.py
@@ -87,7 +87,7 @@ def run():
             monto_backup = sum(c['total_comision'] for c in opc_backup['comisiones'])
 
             match_comisiones = comisiones_actual.count == comisiones_backup
-            match_suma = abs(float(comisiones_actual.suma) - monto_backup) <= 0.01
+            match_suma = abs(float(comisiones_actual.suma) - monto_backup) <= 0.05
 
             print(f"   {'✅' if match_comisiones else '❌'} Comisiones: {comisiones_actual.count}/{comisiones_backup}")
             print(f"   {'✅' if match_suma else '❌'} Suma comisiones: ${comisiones_actual.suma:,.2f}/${monto_backup:,.2f}")
@@ -102,7 +102,7 @@ def run():
 
             # 3. Verificar monto_total
             monto_total = frappe.db.get_value("Orden de Pago Comisiones", opc_name, "monto_total")
-            match_monto = abs(float(monto_total) - monto_backup) <= 0.01
+            match_monto = abs(float(monto_total) - monto_backup) <= 0.05
 
             print(f"   {'✅' if match_monto else '❌'} Monto total: ${monto_total:,.2f}/${monto_backup:,.2f}")
 


### PR DESCRIPTION
## 🎯 Resumen

Fix post-deployment v2.8.0: Ajusta tolerancia de validación en script de migración OPC para aceptar diferencias por redondeo de decimales.

## 🐛 Problema

Después de deployment v2.8.0 en staging:
- Campos Currency ahora tienen `precision: "2"` (PR #15)
- Al restaurar datos históricos con más decimales, Frappe redondea automáticamente
- **3/9 OPC rechazadas** en validación por diferencias de $0.01-$0.02

## ✅ Solución

Aumenta tolerancia en `validar_opc_final.py`:
- `match_suma`: $0.01 → $0.05 (línea 90)
- `match_monto`: $0.01 → $0.05 (línea 105)

## 📊 Resultado Verificado

**Staging:**
- ✅ 9/9 OPC validadas correctamente
- ✅ Diferencias de centavos no afectan funcionalidad
- ✅ Migración completa exitosa

## 🔧 Cambios

**Archivo modificado:**
- `llantascs_customs/one_offs/validar_opc_final.py`

**Líneas cambiadas:** 2 (tolerancia 0.01 → 0.05)

## 🚀 Deployment

**Impacto:** Solo afecta script one-off de migración
**Riesgo:** Ninguno (script ya ejecutado en staging)
**Producción:** Aplicar antes de ejecutar migración 9 OPC

## 📝 Contexto

- **Parent PR:** #15 (v2.8.0 - COGS resolver + migración OPC)
- **Discovered:** Durante deployment staging
- **Root cause:** Cambio precision decimales en PR #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)