### PR TITLE
feat(navigation): add v16 Workspace Sidebars and Desktop Icons for Cockpit and Comisiones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # CLAUDE.md — llantascs_customs
 
+> **Reglas de operación Claude Code** (commits, PRs, base de datos, flujo de trabajo, prohibiciones git):
+> Ver `/home/erpnext/Developer/frappe-infrastructure/.claude/CLAUDE.md`
+
+---
+
 ## Estado de migración
 - **Migrada a v16:** No
 - **Versión origen:** v15 (Frappe 15.97, ERPNext 15.95)
@@ -152,3 +157,44 @@ bench --site llantascs.dev run-tests --app llantascs_customs
 ## Auditoría pre-migración
 
 Ver `docs/adr/0000-estado-real-pre-migracion.md` — estado completo documentado el 2026-04-30.
+
+---
+
+## REGLAS GIT — LLANTASCS CUSTOMS
+
+### Antes de cada commit
+
+- Correr linters en archivos modificados:
+  ```bash
+  ruff format <archivos .py modificados>
+  npx prettier@2.7.1 --write <archivos .js modificados>
+  ```
+
+### Antes de cada PR
+
+- [ ] Linters pasados (ver arriba)
+- [ ] Fixtures exportados si hubo cambios de Custom Fields, Roles, Workspaces, Dashboard Charts
+- [ ] Patch creado si hay cambios de esquema — **requiere autorización explícita del usuario**
+- [ ] `bench --site llantascs-v16.dev migrate` limpio
+- [ ] Ver checklist global en `frappe-infrastructure/CONTRIBUTING.md`
+
+### PROHIBICIÓN ABSOLUTA — NUNCA TRABAJAR EN DEVELOP
+
+**`develop` es la rama protegida de llantascs_customs. Es el equivalente a `main` en otros proyectos del ecosistema.**
+
+- **Nunca implementar cambios estando en `develop`.**
+- **Nunca crear commits estando en `develop`.**
+- **Nunca preparar commits estando en `develop`.**
+- Todo cambio debe iniciar en una rama feature creada desde `develop` limpio.
+- Antes de tocar cualquier archivo, confirmar rama: `git branch --show-current`
+- Si la rama es `develop`, **detenerse inmediatamente** y crear rama feature.
+- Si ya hay cambios en `develop`, **detenerse** y pedir autorización para rescatarlos a rama.
+- `/ship commit` y `/ship commit-push` deben rechazar si la rama es `develop`.
+- `/ship pr` debe exigir rama distinta de `develop`.
+
+### Reglas específicas del proyecto
+
+- PRs siempre a `develop` — es la rama default/protegida de este repo
+- La rama `develop` es el equivalente a `main` (uniformizar nombre en el futuro)
+- Site de desarrollo v16: `llantascs-v16.dev`
+- Site de desarrollo v15 (producción activa): `llantascs.dev`

--- a/llantascs_customs/desktop_icon/cockpit.json
+++ b/llantascs_customs/desktop_icon/cockpit.json
@@ -1,0 +1,17 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Desktop Icon",
+ "hidden": 0,
+ "icon": "activity",
+ "icon_type": "Link",
+ "label": "Cockpit",
+ "link_to": "Cockpit",
+ "link_type": "Workspace Sidebar",
+ "name": "Cockpit",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ],
+ "standard": 1
+}

--- a/llantascs_customs/desktop_icon/comisiones.json
+++ b/llantascs_customs/desktop_icon/comisiones.json
@@ -1,0 +1,25 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Desktop Icon",
+ "hidden": 0,
+ "icon_type": "Link",
+ "label": "Comisiones",
+ "link_to": "Comisiones",
+ "link_type": "Workspace Sidebar",
+ "name": "Comisiones",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Llantas CS Manager"
+  },
+  {
+   "role": "Llantas CS User"
+  },
+  {
+   "role": "Employee"
+  }
+ ],
+ "standard": 1
+}

--- a/llantascs_customs/workspace_sidebar/cockpit.json
+++ b/llantascs_customs/workspace_sidebar/cockpit.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "activity",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Cockpit",
+ "standard": 1,
+ "title": "Cockpit"
+}

--- a/llantascs_customs/workspace_sidebar/comisiones.json
+++ b/llantascs_customs/workspace_sidebar/comisiones.json
@@ -1,0 +1,75 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Comisiones",
+   "link_to": "Comisiones",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Vendedores",
+   "link_to": "Vendedores",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Pagos OPC (Por Sucursal)",
+   "link_to": "Pagos OPC - Por Sucursal",
+   "link_type": "Report",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Mis Comisiones",
+   "link_to": "Mis Comisiones Backlog",
+   "link_type": "Report",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Detalle de comisiones pagadas",
+   "link_to": "Comisiones por Vendedor Detalle",
+   "link_type": "Report",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Backlog Comisiones GP nativo",
+   "link_to": "Backlog Comisiones GP nativo",
+   "link_type": "Report",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Comisiones",
+ "standard": 1,
+ "title": "Comisiones"
+}

--- a/llantascs_customs/workspace_sidebar/dg_analisis_sucursales.json
+++ b/llantascs_customs/workspace_sidebar/dg_analisis_sucursales.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "branch",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "DG Analisis Sucursales",
+ "standard": 1,
+ "title": "DG Analisis Sucursales"
+}

--- a/llantascs_customs/workspace_sidebar/direccion_financiera.json
+++ b/llantascs_customs/workspace_sidebar/direccion_financiera.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "accounting",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Direccion Financiera",
+ "standard": 1,
+ "title": "Direccion Financiera"
+}

--- a/llantascs_customs/workspace_sidebar/direccion_general.json
+++ b/llantascs_customs/workspace_sidebar/direccion_general.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "dashboard",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Direccion General",
+ "standard": 1,
+ "title": "Direccion General"
+}

--- a/llantascs_customs/workspace_sidebar/direccion_operativa.json
+++ b/llantascs_customs/workspace_sidebar/direccion_operativa.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "tool",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Direccion Operativa",
+ "standard": 1,
+ "title": "Direccion Operativa"
+}

--- a/llantascs_customs/workspace_sidebar/gerente_de_sucursal.json
+++ b/llantascs_customs/workspace_sidebar/gerente_de_sucursal.json
@@ -1,0 +1,82 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "header_icon": "branch",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "activity",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Cockpit",
+   "link_to": "Cockpit",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "dashboard",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion General",
+   "link_to": "Direccion General",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "tool",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Operativa",
+   "link_to": "Direccion Operativa",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "accounting",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Direccion Financiera",
+   "link_to": "Direccion Financiera",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Gerente de Sucursal",
+   "link_to": "Gerente de Sucursal",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "branch",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "DG Analisis Sucursales",
+   "link_to": "DG Analisis Sucursales",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Gerente de Sucursal",
+ "standard": 1,
+ "title": "Gerente de Sucursal"
+}

--- a/llantascs_customs/workspace_sidebar/vendedores.json
+++ b/llantascs_customs/workspace_sidebar/vendedores.json
@@ -1,0 +1,42 @@
+{
+ "app": "llantascs_customs",
+ "doctype": "Workspace Sidebar",
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Comisiones",
+   "link_to": "Comisiones",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Vendedores",
+   "link_to": "Vendedores",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Comisiones por Vendedor Detalle",
+   "link_to": "Comisiones por Vendedor Detalle",
+   "link_type": "Report",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "name": "Vendedores",
+ "standard": 1,
+ "title": "Vendedores"
+}


### PR DESCRIPTION
## Objetivo

Implementar la capa de navegación de Frappe v16 para los workspaces ejecutivos
(Cockpit) y de comisiones (Comisiones/Vendedores), que en v16 requieren
`Workspace Sidebar` y `Desktop Icon` además del `Workspace`.

## Cambios principales

### `f572e6d` — feat(cockpit): Workspace Sidebar y Desktop Icon para Cockpit
- `desktop_icon/cockpit.json`: ícono visible en desk, restringido a System Manager
- `workspace_sidebar/cockpit.json`: sidebar con los 6 workspaces ejecutivos
- `workspace_sidebar/direccion_general.json`, `direccion_operativa.json`,
  `direccion_financiera.json`, `gerente_de_sucursal.json`,
  `dg_analisis_sucursales.json`: cada workspace hijo tiene su propio sidebar
  con los mismos 6 ítems de navegación, garantizando que el menú Cockpit
  permanece visible sin importar en qué tablero ejecutivo esté el usuario

### `25c01df` — docs(claude): reglas git y estructura alineada con facturacion_mexico
- Bloque de referencia al CLAUDE.md global de frappe-infrastructure
- Sección `## REGLAS GIT — LLANTASCS CUSTOMS` con `develop` como rama protegida
- `settings.local.json` ampliado (6 → 39 permisos: git, gh, bench v15+v16, linters)
- Symlink `.claude/commands` → `frappe-infrastructure/.claude/commands`

### `9723489` — feat(comisiones): Workspace Sidebar y Desktop Icon para Comisiones
- `desktop_icon/comisiones.json`: ícono visible en desk para roles Llantas CS
- `workspace_sidebar/comisiones.json`: sidebar con navegación inter-workspace
  (Comisiones + Vendedores) y accesos directos a reportes de comisiones
- `workspace_sidebar/vendedores.json`: sidebar con regreso a Comisiones y
  acceso al reporte de detalle

En `bench migrate`, Frappe sincroniza los nuevos `Workspace Sidebar` y
`Desktop Icon` declarativos como registros `standard=1` gestionados por la app.

## Validaciones realizadas

- `bench --site llantascs-v16.dev migrate` — limpio, sin errores
- Verificación visual en browser: ícono Cockpit aparece en desk, navegación
  entre workspaces ejecutivos funciona correctamente
- Verificación visual en browser: ícono Comisiones aparece en desk y funciona
- Verificado en BD: 2 Desktop Icons y 8 Workspace Sidebars con `standard=1,
  app=llantascs_customs`

## Fuera de alcance

- Workspace Comisiones v15 (bench v15 / llantascs.dev) — no modificado
- Tests automatizados — no aplica para configuración declarativa
- Reporte `backlog_comisiones_gp_nativo` (falta `.json`) — problema preexistente

## Riesgos / pendientes

- Requiere `bench --site <sitio> migrate` en cada sitio donde esté instalada la app
- El reporte `Backlog Comisiones GP nativo` referenciado en el sidebar de Comisiones
  existe como código pero sin `.json` de declaración — el link en sidebar no navega