### PR TITLE
fix(override): skip Item variant attributes with None value in custom_create_variant

### DIFF
--- a/llantascs_customs/controllers/override.py
+++ b/llantascs_customs/controllers/override.py
@@ -1,63 +1,68 @@
 import frappe
 import json
-from frappe import _
 from frappe.utils import cstr
 
 from erpnext.controllers.item_variant import copy_attributes_to_variant
 
+
 @frappe.whitelist()
 def custom_create_variant(item, args, use_template_image=False):
-	use_template_image = frappe.parse_json(use_template_image)
-	if isinstance(args, str):
-		args = json.loads(args)
+    use_template_image = frappe.parse_json(use_template_image)
+    if isinstance(args, str):
+        args = json.loads(args)
 
-	template = frappe.get_doc("Item", item)
-	variant = frappe.new_doc("Item")
-	variant.variant_based_on = "Item Attribute"
-	variant_attributes = []
+    template = frappe.get_doc("Item", item)
+    variant = frappe.new_doc("Item")
+    variant.variant_based_on = "Item Attribute"
+    variant_attributes = []
 
-	for d in template.attributes:
-		variant_attributes.append({"attribute": d.attribute, "attribute_value": args.get(d.attribute)})
+    for d in template.attributes:
+        value = args.get(d.attribute)
+        if value is not None:
+            variant_attributes.append(
+                {"attribute": d.attribute, "attribute_value": value}
+            )
 
-	variant.set("attributes", variant_attributes)
-	copy_attributes_to_variant(template, variant)
+    variant.set("attributes", variant_attributes)
+    copy_attributes_to_variant(template, variant)
 
-	if use_template_image and template.image:
-		variant.image = template.image
+    if use_template_image and template.image:
+        variant.image = template.image
 
-	make_variant_item_code(template.item_code, template.item_name, variant)
+    make_variant_item_code(template.item_code, template.item_name, variant)
 
-	return variant
+    return variant
 
 
 def make_variant_item_code(template_item_code, template_item_name, variant):
-	"""Uses template's item code and abbreviations to make variant's item code"""
-	if variant.item_code:
-		return
+    """Uses template's item code and abbreviations to make variant's item code"""
+    if variant.item_code:
+        return
 
-	abbreviations = []
-	for attr in variant.attributes:
-		item_attribute = frappe.db.sql(
-			"""select i.numeric_values, v.abbr
+    abbreviations = []
+    for attr in variant.attributes:
+        item_attribute = frappe.db.sql(
+            """select i.numeric_values, v.abbr
 			from `tabItem Attribute` i left join `tabItem Attribute Value` v
 				on (i.name=v.parent)
 			where i.name=%(attribute)s and (v.attribute_value=%(attribute_value)s or i.numeric_values = 1)""",
-			{"attribute": attr.attribute, "attribute_value": attr.attribute_value},
-			as_dict=True,
-		)
+            {"attribute": attr.attribute, "attribute_value": attr.attribute_value},
+            as_dict=True,
+        )
 
-		if not item_attribute:
-			continue
-			# frappe.throw(_('Invalid attribute {0} {1}').format(frappe.bold(attr.attribute),
-			# 	frappe.bold(attr.attribute_value)), title=_('Invalid Attribute'),
-			# 	exc=InvalidItemAttributeValueError)
+        if not item_attribute:
+            continue
+            # frappe.throw(_('Invalid attribute {0} {1}').format(frappe.bold(attr.attribute),
+            # 	frappe.bold(attr.attribute_value)), title=_('Invalid Attribute'),
+            # 	exc=InvalidItemAttributeValueError)
 
-		abbr_or_value = (
-			cstr(attr.attribute_value) if item_attribute[0].numeric_values else item_attribute[0].abbr
-		)
-		abbreviations.append(abbr_or_value)
+        abbr_or_value = (
+            cstr(attr.attribute_value)
+            if item_attribute[0].numeric_values
+            else item_attribute[0].abbr
+        )
+        abbreviations.append(abbr_or_value)
 
-	if abbreviations:
-		variant.item_code = "{} {}".format(template_item_code, " ".join(abbreviations))
-		variant.item_name = "{} {}".format(template_item_name, " ".join(abbreviations))
-
+    if abbreviations:
+        variant.item_code = "{} {}".format(template_item_code, " ".join(abbreviations))
+        variant.item_name = "{} {}".format(template_item_name, " ".join(abbreviations))


### PR DESCRIPTION
## Objetivo

Corregir el error al crear variantes de Item cuando algún atributo del
template no tiene valor seleccionado.

## Cambios principales

- `controllers/override.py`: en `custom_create_variant`, se agrega condición
  `if value is not None` para solo incluir en el variant los atributos que
  tienen un valor explícito en `args`. Antes se incluían todos los atributos
  del template, resultando en `attribute_value=None` para los no seleccionados.
- Eliminado import `from frappe import _` no usado (ruff F401, pre-existente).

## Validaciones realizadas

- Bug reproducido en sitio local tras `bench update` a ERPNext 16.18.3.
- Fix aplicado y verificado manualmente: creación de variante con atributos
  parciales funciona correctamente.
- No requiere `bench migrate` ni `bench build`.

## Fuera de alcance

- Tests automatizados para el override (deuda técnica existente).
- Otros hallazgos del audit de llantascs_customs.

## Riesgos / pendientes

- El fix es consistente con el comportamiento que ERPNext implementa
  en `Item.validate_variant_attributes()` (filtro `cstr(d.attribute_value).strip()`).
- `legacy/commissions-phase1` remota — sin relación, se mantiene intacta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)